### PR TITLE
Fix compilation error in AnticheatMgr.cpp

### DIFF
--- a/src/AnticheatMgr.cpp
+++ b/src/AnticheatMgr.cpp
@@ -102,48 +102,6 @@ void AnticheatMgr::DoToAllGMs(std::function<void(Player*)> exec)
                 exec(player);
 }
 
-void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo, uint32 opcode)
-{
-    if (!sConfigMgr->GetOption<bool>("Anticheat.Enabled", true))
-        return;
-
-    if (player->IsGameMaster())
-        return;
-
-    ObjectGuid key = player->GetGUID();
-
-    if (player->IsInFlight() || player->GetTransport() || player->GetVehicle())
-    {
-        m_Players[key].SetLastInformations(movementInfo, opcode, player->GetMapId(), GetPlayerCurrentSpeedRate(player));
-        return;
-    }
-
-    TeleportHackDetection(player, movementInfo);
-    SpeedHackDetection(player, movementInfo);
-    FlyHackDetection(player, movementInfo);
-    JumpHackDetection(player, movementInfo, opcode);
-    TeleportPlaneHackDetection(player, movementInfo, opcode);
-    ClimbHackDetection(player, movementInfo, opcode);
-    IgnoreControlHackDetection(player, movementInfo, opcode);
-    GravityHackDetection(player, movementInfo);
-    if (player->GetLiquidData().Status == LIQUID_MAP_WATER_WALK)
-    {
-        WalkOnWaterHackDetection(player, movementInfo);
-    }
-    else
-    {
-        ZAxisHackDetection(player, movementInfo);
-    }
-    if (player->GetLiquidData().Status == LIQUID_MAP_UNDER_WATER)
-    {
-        AntiSwimHackDetection(player, movementInfo, opcode);
-    }
-    AntiKnockBackHackDetection(player, movementInfo);
-    NoFallDamageDetection(player, movementInfo);
-    NoclipHackDetection(player, movementInfo);
-    if (Battleground* bg = player->GetBattleground())
-    {
-        if (bg->GetStatus() == STATUS_WAIT_JOIN)
 // Detects noclip hacks by checking if player movement intersects with solid WMO/M2 objects
 void AnticheatMgr::NoclipHackDetection(Player* player, MovementInfo movementInfo)
 {
@@ -232,7 +190,49 @@ bool AnticheatMgr::LineAABBIntersect(float sx, float sy, float sz, float ex, flo
     // TODO: Implement full line-AABB intersection for more accuracy
     return false;
 }
-}
+
+void AnticheatMgr::StartHackDetection(Player* player, MovementInfo movementInfo, uint32 opcode)
+{
+    if (!sConfigMgr->GetOption<bool>("Anticheat.Enabled", true))
+        return;
+
+    if (player->IsGameMaster())
+        return;
+
+    ObjectGuid key = player->GetGUID();
+
+    if (player->IsInFlight() || player->GetTransport() || player->GetVehicle())
+    {
+        m_Players[key].SetLastInformations(movementInfo, opcode, player->GetMapId(), GetPlayerCurrentSpeedRate(player));
+        return;
+    }
+
+    TeleportHackDetection(player, movementInfo);
+    SpeedHackDetection(player, movementInfo);
+    FlyHackDetection(player, movementInfo);
+    JumpHackDetection(player, movementInfo, opcode);
+    TeleportPlaneHackDetection(player, movementInfo, opcode);
+    ClimbHackDetection(player, movementInfo, opcode);
+    IgnoreControlHackDetection(player, movementInfo, opcode);
+    GravityHackDetection(player, movementInfo);
+    if (player->GetLiquidData().Status == LIQUID_MAP_WATER_WALK)
+    {
+        WalkOnWaterHackDetection(player, movementInfo);
+    }
+    else
+    {
+        ZAxisHackDetection(player, movementInfo);
+    }
+    if (player->GetLiquidData().Status == LIQUID_MAP_UNDER_WATER)
+    {
+        AntiSwimHackDetection(player, movementInfo, opcode);
+    }
+    AntiKnockBackHackDetection(player, movementInfo);
+    NoFallDamageDetection(player, movementInfo);
+    NoclipHackDetection(player, movementInfo);
+    if (Battleground* bg = player->GetBattleground())
+    {
+        if (bg->GetStatus() == STATUS_WAIT_JOIN)
         {
             BGStartExploit(player, movementInfo);
         }


### PR DESCRIPTION
The function definition for `NoclipHackDetection` and its helper `LineAABBIntersect` were incorrectly placed inside the `StartHackDetection` function, causing a compilation error. This commit moves the function definitions to the correct scope, which fixes the error.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
